### PR TITLE
Use secrets for property details in workflow

### DIFF
--- a/.github/workflows/scrape.yml
+++ b/.github/workflows/scrape.yml
@@ -8,6 +8,10 @@ on:
 jobs:
   scrape:
     runs-on: ubuntu-latest
+    env:
+      UPRN: ${{ secrets.UPRN }}
+      POSTCODE: ${{ secrets.POSTCODE }}
+      HOUSE_NUMBER_OR_NAME: ${{ secrets.HOUSE_NUMBER_OR_NAME }}
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python
@@ -19,8 +23,4 @@ jobs:
           python -m pip install --upgrade pip
           pip install requests beautifulsoup4
       - name: Run scraper
-        env:
-          UPRN: ${{ secrets.UPRN }}
-          POSTCODE: ${{ secrets.POSTCODE }}
-          HOUSE_NUMBER_OR_NAME: ${{ secrets.HOUSE_NUMBER_OR_NAME }}
         run: python cornwall_collection.py


### PR DESCRIPTION
## Summary
- expose UPRN, POSTCODE and HOUSE_NUMBER_OR_NAME as job env vars in scrape workflow

## Testing
- `python3 -m py_compile cornwall_collection.py`
- `UPRN=100040118005 python3 cornwall_collection.py`


------
https://chatgpt.com/codex/tasks/task_e_68b3491174ac832d9bba6ca2adb3d76a