### PR TITLE
Fix iCalendar generation and rename collection types

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,4 +30,6 @@ A sample environment file is provided as `.env.example`.
    python cornwall_collection.py
    ```
 
-The script will print upcoming collection dates and their types.
+The script will print upcoming collection dates and their types and also
+generate an `cornwall_collection.ics` file that can be imported into any
+calendar application supporting the iCalendar format.


### PR DESCRIPTION
## Summary
- map council collection names to user-friendly event summaries
- generate valid iCalendar events with timestamps and without reminders

## Testing
- `python -m py_compile cornwall_collection.py`
- `UPRN=100040118005 python cornwall_collection.py`


------
https://chatgpt.com/codex/tasks/task_e_68b34c9bca58832d9666622bed817bea