### PR TITLE
feat: allow disabling collection events

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,3 +2,9 @@
 UPRN=100040118005
 #POSTCODE=
 #HOUSE_NUMBER_OR_NAME=
+
+# Optional: set to "false" to disable individual collection types
+#INCLUDE_FOOD=true
+#INCLUDE_RECYCLING=true
+#INCLUDE_RUBBISH=true
+#INCLUDE_GARDEN=true

--- a/.github/workflows/scrape.yml
+++ b/.github/workflows/scrape.yml
@@ -15,6 +15,10 @@ jobs:
       UPRN: ${{ secrets.UPRN }}
       POSTCODE: ${{ secrets.POSTCODE }}
       HOUSE_NUMBER_OR_NAME: ${{ secrets.HOUSE_NUMBER_OR_NAME }}
+      INCLUDE_FOOD: ${{ secrets.INCLUDE_FOOD }}
+      INCLUDE_RECYCLING: ${{ secrets.INCLUDE_RECYCLING }}
+      INCLUDE_RUBBISH: ${{ secrets.INCLUDE_RUBBISH }}
+      INCLUDE_GARDEN: ${{ secrets.INCLUDE_GARDEN }}
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python

--- a/README.md
+++ b/README.md
@@ -12,7 +12,17 @@ which to fetch collection information:
 - `POSTCODE` – Postcode of the property (used when `UPRN` is not set).
 - `HOUSE_NUMBER_OR_NAME` – House number or name (used with `POSTCODE`).
 
-A sample environment file is provided as `.env.example`.
+Optional variables allow disabling generation of specific collection types. If
+unset, all events are created.
+
+- `INCLUDE_FOOD` – set to `false` to skip Food Waste Collection events.
+- `INCLUDE_RECYCLING` – set to `false` to skip Recycling Collection events.
+- `INCLUDE_RUBBISH` – set to `false` to skip Rubbish Recycling events.
+- `INCLUDE_GARDEN` – set to `false` to skip Garden Waste Collection events.
+
+A sample environment file is provided as `.env.example`. When using the
+included GitHub Actions workflow, add these variables (including any optional
+`INCLUDE_*` values) as repository secrets.
 
 ## Usage
 

--- a/cornwall_collection.py
+++ b/cornwall_collection.py
@@ -29,6 +29,24 @@ NAME_MAP = {
     "Garden": "Garden Waste Collection",
 }
 
+# Environment variable names to toggle individual collections. By default all
+# events are created unless a value evaluates to ``false``.
+INCLUDE_VARS = {
+    "Food Waste Collection": "INCLUDE_FOOD",
+    "Recycling Collection": "INCLUDE_RECYCLING",
+    "Rubbish Recycling": "INCLUDE_RUBBISH",
+    "Garden Waste Collection": "INCLUDE_GARDEN",
+}
+
+
+def _is_enabled(collection_name: str) -> bool:
+    """Return ``True`` if the given collection should be included."""
+    env_var = INCLUDE_VARS.get(collection_name)
+    value = os.getenv(env_var) if env_var else None
+    if value is None:
+        return True
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
 
 @dataclass
 class Collection:
@@ -151,6 +169,7 @@ def main() -> None:
         print(f"Error fetching data: {exc}")
         return
 
+    collections = [c for c in collections if _is_enabled(c.type)]
     for c in collections:
         print(f"{c.date:%Y-%m-%d} - {c.type}")
 


### PR DESCRIPTION
## Summary
- allow skipping specific collection types through INCLUDE_* env vars
- document new variables and add examples for local config and GitHub Secrets
- wire up GitHub workflow to pass through the optional secrets

## Testing
- `python -m py_compile cornwall_collection.py`
- `UPRN=100040118005 INCLUDE_GARDEN=false python cornwall_collection.py`


------
https://chatgpt.com/codex/tasks/task_e_68b4af488704832d9a464ec62c251f74